### PR TITLE
Fix issue #3: contributions page - cancel call to ohsome when a component is unloaded

### DIFF
--- a/frontend/src/api/stats.js
+++ b/frontend/src/api/stats.js
@@ -1,7 +1,13 @@
 import { useQuery } from '@tanstack/react-query';
 
+import { fetchExternalJSONAPI } from '../network/genericJSONRequest';
 import api from './apiClient';
 import { OHSOME_STATS_BASE_URL } from '../config';
+
+const ohsomeProxyAPI = (url) => {
+  const token = localStorage.getItem('token');
+  return api(token).get(`users/statistics/ohsome/?url=${url}`);
+};
 
 export const useSystemStatisticsQuery = () => {
   const fetchSystemStats = ({ signal }) => {
@@ -59,5 +65,35 @@ export const useOsmHashtagStatsQuery = (defaultComment) => {
     useErrorBoundary: true,
     enabled: Boolean(defaultComment?.[0]),
     select: (data) => data.data.result,
+  });
+};
+
+export const useUserOsmStatsQuery = (id) => {
+  const fetchUserOsmStats = () => {
+    return ohsomeProxyAPI(
+      `${OHSOME_STATS_BASE_URL}/topic/poi,highway,building,waterway/user?userId=${id}`,
+    );
+  };
+
+  return useQuery({
+    queryKey: ['user-osm-stats'],
+    queryFn: fetchUserOsmStats,
+    // userDetail.test.js fails on CI when useErrorBoundary=true
+    useErrorBoundary: process.env.NODE_ENV !== 'test',
+    select: (data) => data.data.result,
+    enabled: !!id,
+  });
+};
+
+export const useOsmStatsMetadataQuery = () => {
+  const fetchOsmStatsMetadata = () => {
+    return fetchExternalJSONAPI(`${OHSOME_STATS_BASE_URL}/metadata`);
+  };
+
+  return useQuery({
+    queryKey: ['osm-stats-metadata'],
+    queryFn: fetchOsmStatsMetadata,
+    useErrorBoundary: true,
+    select: (data) => data.result,
   });
 };

--- a/frontend/src/views/userDetail.js
+++ b/frontend/src/views/userDetail.js
@@ -55,10 +55,10 @@ export const UserDetail = ({ withHeader = true }) => {
 
   useEffect(() => {
     if (userDetails.id) {
-      fetchExternalJSONAPI(`${OSM_SERVER_URL}/api/0.6/user/${userDetails.id}.json`, false)
+      fetchExternalJSONAPI(`${OSM_SERVER_URL}/api/0.6/user/${userDetails.id}.json`)
         .then((res) => setUserOsmDetails(res?.user))
         .catch((e) => console.log(e));
-      fetchExternalJSONAPI(`${OHSOME_STATS_BASE_URL}/hot-tm-user?userId=${userDetails.id}`, true)
+      fetchExternalJSONAPI(`${OHSOME_STATS_BASE_URL}/hot-tm-user?userId=${userDetails.id}`)
         .then((res) => setOsmStats(res.result))
         .catch((e) => console.log(e));
     }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [X] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

Example: Fixes #3

## Describe this PR

The function `fetchExternalJSONAPI()` was called with an extra boolean parameter. This caused the exception.
This was a known issue in core TM version and was fixed in commit:
https://github.com/hotosm/tasking-manager/commit/56da86bf3076e48fa0c0afc0a44b6ab08a079c83
As we run from aa 4.7.0 already cherrypicked branch, a new cherrypick is required.

## Screenshots
```
git cherry-pick 56da86bf3076e48fa0c0afc0a44b6ab08a079c83
Auto-merging frontend/src/api/stats.js
CONFLICT (content): Merge conflict in frontend/src/api/stats.js
Auto-merging frontend/src/network/genericJSONRequest.js
CONFLICT (content): Merge conflict in frontend/src/network/genericJSONRequest.js
Auto-merging frontend/src/views/userDetail.js
error: could not apply 56da86bf3... Cancel call to ohsome when a component is unloaded
hint: After resolving the conflicts, mark them with
hint: "git add/rm <pathspec>", then run
hint: "git cherry-pick --continue".
hint: You can instead skip this commit with "git cherry-pick --skip".
hint: To abort and get back to the state before "git cherry-pick",
hint: run "git cherry-pick --abort".
just@savu:~/project/openstreetmap/hot/tm/fork.git$ git status
On branch osm-es-4.7.0-issue3
Your branch is up to date with 'origin/osm-es-4.7.0-issue3'.

You are currently cherry-picking commit 56da86bf3.
  (all conflicts fixed: run "git cherry-pick --continue")
  (use "git cherry-pick --skip" to skip this patch)
  (use "git cherry-pick --abort" to cancel the cherry-pick operation)

Changes to be committed:
	modified:   frontend/src/api/stats.js
	modified:   frontend/src/network/genericJSONRequest.js
	modified:   frontend/src/views/userDetail.js

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	modified:   frontend/src/api/stats.js
	modified:   frontend/src/network/genericJSONRequest.js
	modified:   frontend/src/views/userDetail.js

just@savu:~/project/openstreetmap/hot/tm/fork.git$ git add frontend/src/api/stats.js frontend/src/network/genericJSONRequest.js frontend/src/views/userDetail.js 
just@savu:~/project/openstreetmap/hot/tm/fork.git$ git cherry-pick --continue
[osm-es-4.7.0-issue3 1131a5bbd] Cancel call to ohsome when a component is unloaded
 Author: Taylor Smock <tsmock@meta.com>
 Date: Mon Mar 11 14:36:23 2024 -0600
 2 files changed, 38 insertions(+), 2 deletions(-)
just@savu:~/project/openstreetmap/hot/tm/fork.git$ git status
On branch osm-es-4.7.0-issue3
Your branch is ahead of 'origin/osm-es-4.7.0-issue3' by 1 commit.
  (use "git push" to publish your local commits)

nothing to commit, working tree clean
just@savu:~/project/openstreetmap/hot/tm/fork.git$ 
just@savu:~/project/openstreetmap/hot/tm/fork.git$ git add frontend/src/api/stats.js frontend/src/network/genericJSONRequest.js frontend/src/views/userDetail.js 
just@savu:~/project/openstreetmap/hot/tm/fork.git$ git push

```

## Alternative Approaches Considered

No.
## Review Guide

Notes for the reviewer. How to test this change?

## Checklist before requesting a review

- 📖 Read the Tasking Manager Contributing Guide: <https://github.com/hotosm/tasking-manager/blob/develop/docs/developers/contributing.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.
- 🔠 Does this PR introduce or change any environment variables? If so, make sure to specify this change in the description.

## [optional] What gif best describes this PR or how it makes you feel?
Good, hopefully now the contributions page https://tareas.openstreetmap.es/contributions will work again!

